### PR TITLE
fix: handle merge_group github events

### DIFF
--- a/codecov-cli/codecov_cli/helpers/ci_adapters/github_actions.py
+++ b/codecov-cli/codecov_cli/helpers/ci_adapters/github_actions.py
@@ -66,21 +66,21 @@ class GithubActionsCIAdapter(CIAdapterBase):
         return os.getenv("GITHUB_REPOSITORY")
 
     def _get_branch(self):
-        branch = os.getenv("GITHUB_HEAD_REF")
-        if branch:
-            return branch
+        def remove_prefix(s, prefix):
+            if s.startswith(prefix):
+                return s[len(prefix) :]
+            return s
 
-        branch_ref = os.getenv("GITHUB_REF")
+        head_ref = os.getenv("GITHUB_HEAD_REF", "")
+        ref = remove_prefix(os.getenv("GITHUB_REF", ""), "refs/heads/")
 
-        if not branch_ref:
-            return None
+        branch = head_ref or ref
 
-        match = re.search(r"refs/heads/(.*)", branch_ref)
+        # branch format for merge queue CI runs:
+        # gh-readonly-queue/<branch-name>/<pr-number>-<pr-name>
+        if branch.startswith("gh-readonly-queue/"):
+            return branch.split("/")[1]
 
-        if match is None:
-            return None
-
-        branch = match.group(1)
         return branch or None
 
     def _get_service(self):

--- a/codecov-cli/codecov_cli/helpers/ci_adapters/github_actions.py
+++ b/codecov-cli/codecov_cli/helpers/ci_adapters/github_actions.py
@@ -66,10 +66,10 @@ class GithubActionsCIAdapter(CIAdapterBase):
         return os.getenv("GITHUB_REPOSITORY")
 
     def _get_branch(self):
-        def remove_prefix(s, prefix):
+        def remove_prefix(s: str, prefix: str) -> str:
             if s.startswith(prefix):
                 return s[len(prefix) :]
-            return s
+            return ""
 
         head_ref = os.getenv("GITHUB_HEAD_REF", "")
         ref = remove_prefix(os.getenv("GITHUB_REF", ""), "refs/heads/")

--- a/codecov-cli/tests/ci_adapters/test_ghactions.py
+++ b/codecov-cli/tests/ci_adapters/test_ghactions.py
@@ -207,6 +207,12 @@ class TestGithubActions(object):
             ({GithubActionsEnvEnum.GITHUB_REF: r"doesn't_match"}, None),
             ({GithubActionsEnvEnum.GITHUB_REF: r"refs/heads/"}, None),
             ({GithubActionsEnvEnum.GITHUB_REF: r"refs/heads/abc"}, "abc"),
+            (
+                {
+                    GithubActionsEnvEnum.GITHUB_REF: r"refs/heads/gh-readonly-queue/abc/pr-name-number"
+                },
+                "abc",
+            ),
         ],
     )
     def test_branch(self, env_dict, expected, mocker):


### PR DESCRIPTION
if we get a branch with gh-readonly-queue, it comes from a merge queue and the actual branch name is located in the middle