### PR TITLE
chore: Remove publish: false in release flow

### DIFF
--- a/.github/workflows/broadcast_api_changes.yml
+++ b/.github/workflows/broadcast_api_changes.yml
@@ -1,0 +1,36 @@
+---
+# yamllint disable rule:line-length
+
+name: Broadcast API changes
+
+on:
+  push:
+    branches: ['main']
+    paths: ['codecov-cli/codecovcli_commands', 'prevent-cli/preventcli_commands']
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install GitHub CLI
+        uses: dev-hanz-ops/install-gh-cli-action@v0.1.0
+
+      - name: Get auth token
+        id: token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        with:
+          app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Open issue on wrapper
+        run: |
+          gh issue create -R codecov/wrapper -t 'New change on CLI' -b "$(gh pr diff $BRANCH)"
+        env:
+          BRANCH: ${{ github.head_ref }}
+          GH_TOKEN: ${{ steps.token.outputs.token }}

--- a/.github/workflows/release_flow.yml
+++ b/.github/workflows/release_flow.yml
@@ -12,14 +12,14 @@ jobs:
       contents: read  # This is required for actions/checkout
     uses: ./.github/workflows/build_for_pypi.yml
     with:
-      publish: false # todo: back to true when tested
+      publish: true
     secrets: inherit
 
   buildassets:
     name: Build packages
     uses: ./.github/workflows/build_assets.yml
     with:
-      release: false # todo: back to true when tested
+      release: true
     secrets: inherit
 
   publish_to_pypi:


### PR DESCRIPTION
Enabled the release step for our release workflows. Also moves over the last workflow (`broadcast_api_changes.yml`) and rolls release back to 10.4.0 so we can do the release flow again for real.