### PR TITLE
fix: CI being broken

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,14 +30,15 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install -r codecov-cli/requirements.txt
           python -m pip install -e codecov-cli
           python -m pip install -e prevent-cli
 
@@ -100,6 +101,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install -r codecov-cli/requirements.txt
           python -m pip install -e codecov-cli
           python -m pip install -e prevent-cli
           pip install -r codecov-cli/tests/requirements.txt


### PR DESCRIPTION
Fix CI. Apparently there are dependencies in `codecov-cli/requirements.txt` that are not installed by `pip install -e codecov-cli` and are required for CI to run properly. This makes some sense, like dev-dependencies in js. I removed the explicit install of requirements.txt as I thought it was redundant with `pip install -e codecov-cli`.