### PR TITLE
fix: workflow permissions

### DIFF
--- a/.github/workflows/build_assets.yml
+++ b/.github/workflows/build_assets.yml
@@ -9,6 +9,9 @@ on:
         default: false
         description: "Attach artifacts to a release"
 
+permissions:
+  contents: read
+
 jobs:
   build_assets:
     name: Build packages - ${{ matrix.os }}

--- a/.github/workflows/build_for_pypi.yml
+++ b/.github/workflows/build_for_pypi.yml
@@ -9,6 +9,9 @@ on:
         default: false
         description: "Build for PyPi"
 
+permissions:
+  contents: read
+
 jobs:
   build_src_for_pypi:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-job.yml
+++ b/.github/workflows/ci-job.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build-test-upload:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -6,6 +6,9 @@ on:
       - main
     types: [closed]
 
+permissions:
+  contents: read
+
 jobs:
   create-release:
     if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.repository_owner == 'getsentry' }}

--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -7,6 +7,9 @@ on:
         description: 'Name of version  (ie 23.9.5)'
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   create-release-pr:
     name: Create PR

--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions:
+  contents: read
+
 jobs:
   enforce-license-compliance:
     runs-on: ubuntu-latest

--- a/.github/workflows/release_flow.yml
+++ b/.github/workflows/release_flow.yml
@@ -5,6 +5,9 @@ on:
     types:
       - created
 
+permissions:
+  contents: read
+
 jobs:
   build_for_pypi:
     permissions:

--- a/command_dump.py
+++ b/command_dump.py
@@ -31,5 +31,23 @@ def command_dump(commands: list[str], out_path: str):
 
 
 if __name__ == "__main__":
+    try:
+        subprocess.check_call(["codecovcli", "--help"], stdout=subprocess.DEVNULL)
+    except Exception:
+        print(
+            "codecovcli is not executable. You can install it with pip install -e codecov-cli"
+        )
+        exit(1)
+
+    try:
+        subprocess.check_call(
+            ["sentry-prevent-cli", "--help"], stdout=subprocess.DEVNULL
+        )
+    except Exception:
+        print(
+            "sentry-prevent-cli is not executable. You can install it with pip install -e prevent-cli"
+        )
+        exit(1)
+
     command_dump(["codecovcli"], "codecov-cli/codecovcli_commands")
     command_dump(["sentry-prevent-cli"], "prevent-cli/preventcli_commands")

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -2,5 +2,6 @@
 
 set -e
 
-python command_dump.py
-git add codecovcli_commands
+./command_dump.py
+git add codecov-cli/codecovcli_commands
+git add prevent-cli/preventcli_commands


### PR DESCRIPTION
Fixes a bunch of errors in https://github.com/getsentry/prevent-cli/security/code-scanning

also tweaks the pre-commit hook to work with new command dump