### PR TITLE
fix: linux x86_64 build requiring glibc >= 2.35

### DIFF
--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -31,9 +31,11 @@ jobs:
       - name: Update version and push
         id: make-commit
         run: |
-          cd codecov-cli
-          sed -i "s/version\ =\ \"[0-9]\+\.[0-9]\+\.[0-9]\+\"/version\ =\ \"$VERSION_NAME\"/g" pyproject.toml
-          git add pyproject.toml
+          sed -i "s/version\ =\ \"[0-9]\+\.[0-9]\+\.[0-9]\+\"/version\ =\ \"$VERSION_NAME\"/g" codecov-cli/pyproject.toml
+          pip install uv
+          uv sync --project codecov-cli # updates uv.lock
+          uv sync --project prevent-cli
+          git add .
           git commit --message "Prepare release $VERSION_NAME"
           echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           git push origin release/"$VERSION_NAME"

--- a/.github/workflows/release_flow.yml
+++ b/.github/workflows/release_flow.yml
@@ -4,14 +4,12 @@ on:
   release:
     types:
       - created
-  push:
 
 permissions:
   contents: read
 
 jobs:
   build_for_pypi:
-    if: false
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -35,7 +33,6 @@ jobs:
           path: ./codecov-cli/dist/*
 
   publish_to_pypi:
-    if: false
     needs: build_for_pypi
     permissions:
       id-token: write  # This is required for OIDC
@@ -70,14 +67,6 @@ jobs:
               uv run pyinstaller --target-arch universal2 -F codecov_cli/main.py &&
               mv dist/main dist/codecovcli_macos
             OUT_FILE_NAME: codecovcli_macos
-            ASSET_MIME: application/octet-stream
-
-          - os: ubuntu-22.04
-            TARGET: ubuntu
-            CMD_BUILD: >
-              uv run pyinstaller -F codecov_cli/main.py &&
-              mv ./dist/main ./dist/codecovcli_linux
-            OUT_FILE_NAME: codecovcli_linux
             ASSET_MIME: application/octet-stream
 
           - os: windows-latest
@@ -124,8 +113,8 @@ jobs:
           tag: ${{ github.ref }}
           overwrite: true
 
-  build_assets_alpine_arm:
-    name: Build Linux assets - glibc and musl, ARM and x86
+  build_linux_assets:
+    name: Build Linux assets - glibc and musl, arm64 and x86_64
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -161,14 +150,14 @@ jobs:
           ${{ matrix.distro }} \
           ./codecov-cli/scripts/build_${{ matrix.distro_name }}.sh ${{ matrix.distro_name }}_${{ matrix.arch }}
 
-    - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: codecovcli_${{ matrix.distro_name }}_${{ matrix.arch }}
-        path: ./codecov-cli/dist/codecovcli_*
+    # # Useful for testing
+    # - name: Upload build artifacts
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: codecovcli_${{ matrix.distro_name }}_${{ matrix.arch }}
+    #     path: ./codecov-cli/dist/codecovcli_*
 
     - name: Get auth token
-      if: false
       id: token
       uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
       with:
@@ -176,7 +165,6 @@ jobs:
         private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
 
     - name: Upload Release Asset
-      if: false
       id: upload-release-asset
       uses: svenstaro/upload-release-action@v2
       with:
@@ -187,9 +175,8 @@ jobs:
         overwrite: true
 
   publish_release:
-    if: false
     name: Publish release
-    needs: [build_assets, build_assets_alpine_arm, build_for_pypi, publish_to_pypi]
+    needs: [build_assets, build_linux_assets, build_for_pypi, publish_to_pypi]
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'

--- a/.github/workflows/release_flow.yml
+++ b/.github/workflows/release_flow.yml
@@ -4,12 +4,14 @@ on:
   release:
     types:
       - created
+  push:
 
 permissions:
   contents: read
 
 jobs:
   build_for_pypi:
+    if: false
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -33,6 +35,7 @@ jobs:
           path: ./codecov-cli/dist/*
 
   publish_to_pypi:
+    if: false
     needs: build_for_pypi
     permissions:
       id-token: write  # This is required for OIDC
@@ -122,20 +125,23 @@ jobs:
           overwrite: true
 
   build_assets_alpine_arm:
-    name: Build assets - Alpine and ARM
+    name: Build Linux assets - glibc and musl, ARM and x86
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
-          - distro: "python:3.11-alpine"
+          - distro: "alpine:3.21"
             arch: arm64
             distro_name: alpine
-          - distro: "python:3.11-alpine"
+          - distro: "alpine:3.21"
             arch: x86_64
             distro_name: alpine
-          - distro: "python:3.11-bullseye"
+          - distro: "ubuntu:20.04"
             arch: arm64
             distro_name: linux
+          - distro: "ubuntu:20.04" # 20.04 needed for glibc 2.31 compatibility
+            distro_name: linux
+            arch: x86_64
 
     steps:
     - uses: actions/checkout@v4
@@ -153,9 +159,16 @@ jobs:
           -w ${{ github.workspace }} \
           --platform linux/${{ matrix.arch }} \
           ${{ matrix.distro }} \
-          ./codecov-cli/scripts/build_${{ matrix.distro_name }}_arm.sh ${{ matrix.distro_name }}_${{ matrix.arch }}
+          ./codecov-cli/scripts/build_${{ matrix.distro_name }}.sh ${{ matrix.distro_name }}_${{ matrix.arch }}
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: codecovcli_${{ matrix.distro_name }}_${{ matrix.arch }}
+        path: ./codecov-cli/dist/codecovcli_*
 
     - name: Get auth token
+      if: false
       id: token
       uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
       with:
@@ -163,6 +176,7 @@ jobs:
         private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
 
     - name: Upload Release Asset
+      if: false
       id: upload-release-asset
       uses: svenstaro/upload-release-action@v2
       with:
@@ -173,6 +187,7 @@ jobs:
         overwrite: true
 
   publish_release:
+    if: false
     name: Publish release
     needs: [build_assets, build_assets_alpine_arm, build_for_pypi, publish_to_pypi]
     runs-on: ubuntu-latest

--- a/codecov-cli/scripts/build_alpine.sh
+++ b/codecov-cli/scripts/build_alpine.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
-apk add build-base
+apk add build-base python3 py3-pip
 cd codecov-cli
 pip install uv
 uv sync
 uv add --dev pyinstaller
 uv run pyinstaller -F codecov_cli/main.py
-cp ./dist/main ./dist/codecovcli_$1
+mv ./dist/main ./dist/codecovcli_$1

--- a/codecov-cli/scripts/build_alpine.sh
+++ b/codecov-cli/scripts/build_alpine.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 apk add build-base python3 py3-pip
 cd codecov-cli
-pip install uv
+pip install uv --break-system-packages
 uv sync
 uv add --dev pyinstaller
 uv run pyinstaller -F codecov_cli/main.py

--- a/codecov-cli/scripts/build_linux.sh
+++ b/codecov-cli/scripts/build_linux.sh
@@ -2,7 +2,7 @@
 apt update
 apt install -y build-essential python3 python3-pip
 cd codecov-cli
-pip install uv --break-system-packages
+pip install uv
 uv sync
 uv add --dev pyinstaller
 uv run pyinstaller -F codecov_cli/main.py

--- a/codecov-cli/scripts/build_linux.sh
+++ b/codecov-cli/scripts/build_linux.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-apt install build-essential python3 python3-pip
+apt update
+apt install -y build-essential python3 python3-pip
 cd codecov-cli
 pip install uv --break-system-packages
 uv sync

--- a/codecov-cli/scripts/build_linux.sh
+++ b/codecov-cli/scripts/build_linux.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 apt install build-essential python3 python3-pip
 cd codecov-cli
-pip install uv
+pip install uv --break-system-packages
 uv sync
 uv add --dev pyinstaller
 uv run pyinstaller -F codecov_cli/main.py

--- a/codecov-cli/scripts/build_linux.sh
+++ b/codecov-cli/scripts/build_linux.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+apt install build-essential python3 python3-pip
+cd codecov-cli
+pip install uv
+uv sync
+uv add --dev pyinstaller
+uv run pyinstaller -F codecov_cli/main.py
+mv ./dist/main ./dist/codecovcli_$1
+
+# linux binary should be just codecovcli_linux
+if [ $1 = "linux_x86_64" ]; then
+    mv ./dist/codecovcli_$1 ./dist/codecovcli_linux
+fi

--- a/codecov-cli/scripts/build_linux_arm.sh
+++ b/codecov-cli/scripts/build_linux_arm.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-apt install build-essential
-cd codecov-cli
-pip install uv
-uv sync
-uv add --dev pyinstaller
-uv run pyinstaller -F codecov_cli/main.py
-cp ./dist/main ./dist/codecovcli_$1

--- a/codecov-cli/uv.lock
+++ b/codecov-cli/uv.lock
@@ -112,7 +112,7 @@ wheels = [
 
 [[package]]
 name = "codecov-cli"
-version = "11.0.0"
+version = "11.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/prevent-cli/uv.lock
+++ b/prevent-cli/uv.lock
@@ -99,7 +99,7 @@ wheels = [
 
 [[package]]
 name = "codecov-cli"
-version = "11.0.0"
+version = "11.0.1"
 source = { directory = "../codecov-cli" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes our build to make the glibc x86_64 linux binary runnable on glibc >= 2.31. Previously we were building on 2.35 and due to dynamic linking, running with an older glibc version would fail (e.g., on ubuntu:20.04).