### PR TITLE
fix: build with python 3.9

### DIFF
--- a/.github/workflows/release_flow.yml
+++ b/.github/workflows/release_flow.yml
@@ -4,12 +4,14 @@ on:
   release:
     types:
       - created
+  push:
 
 permissions:
   contents: read
 
 jobs:
   build_for_pypi:
+    if: false
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -33,6 +35,7 @@ jobs:
           path: ./codecov-cli/dist/*
 
   publish_to_pypi:
+    if: false
     needs: build_for_pypi
     permissions:
       id-token: write # This is required for OIDC
@@ -96,6 +99,7 @@ jobs:
         run: cd codecov-cli && ${{matrix.CMD_BUILD}}
 
       - name: Get auth token
+        if: false
         id: token
         uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         with:
@@ -103,6 +107,7 @@ jobs:
           private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Upload Release Asset
+        if: false
         id: upload-release-asset
         uses: svenstaro/upload-release-action@v2
         with:
@@ -156,6 +161,7 @@ jobs:
       #     path: ./codecov-cli/dist/codecovcli_*
 
       - name: Get auth token
+        if: false
         id: token
         uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         with:
@@ -163,6 +169,7 @@ jobs:
           private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Upload Release Asset
+        if: false
         id: upload-release-asset
         uses: svenstaro/upload-release-action@v2
         with:
@@ -173,6 +180,7 @@ jobs:
           overwrite: true
 
   publish_release:
+    if: false
     name: Publish release
     needs: [build_assets, build_linux_assets, build_for_pypi, publish_to_pypi]
     runs-on: ubuntu-latest

--- a/.github/workflows/release_flow.yml
+++ b/.github/workflows/release_flow.yml
@@ -4,7 +4,6 @@ on:
   release:
     types:
       - created
-  push:
 
 permissions:
   contents: read
@@ -97,7 +96,6 @@ jobs:
         run: cd codecov-cli && ${{matrix.CMD_BUILD}}
 
       - name: Get auth token
-        if: false
         id: token
         uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         with:
@@ -105,7 +103,6 @@ jobs:
           private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Upload Release Asset
-        if: false
         id: upload-release-asset
         uses: svenstaro/upload-release-action@v2
         with:
@@ -121,7 +118,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - distro: "alpine:3.14" # alpine 3.14 needed for musl 1.2.2 and python 3.9 compatibility
+          - distro: "alpine:3.14" # alpine 3.14 needed for musl 1.2.2/python 3.9 compatibility
             arch: arm64
             distro_name: alpine
             runs-on: ubuntu-24.04-arm
@@ -129,7 +126,7 @@ jobs:
             arch: x86_64
             distro_name: alpine
             runs-on: ubuntu-24.04
-          - distro: "ubuntu:20.04" # ubuntu 20.04 needed for glibc 2.31 and python 3.9 compatibility
+          - distro: "ubuntu:20.04" # ubuntu 20.04 needed for glibc 2.31/python 3.9 compatibility
             arch: arm64
             distro_name: linux
             runs-on: ubuntu-24.04-arm
@@ -151,15 +148,14 @@ jobs:
             ${{ matrix.distro }} \
             ./codecov-cli/scripts/build_${{ matrix.distro_name }}.sh ${{ matrix.distro_name }}_${{ matrix.arch }}
 
-      # Useful for testing
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: codecovcli_${{ matrix.distro_name }}_${{ matrix.arch }}
-          path: ./codecov-cli/dist/codecovcli_*
+      # # Useful for testing
+      # - name: Upload build artifacts
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: codecovcli_${{ matrix.distro_name }}_${{ matrix.arch }}
+      #     path: ./codecov-cli/dist/codecovcli_*
 
       - name: Get auth token
-        if: false
         id: token
         uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         with:
@@ -167,7 +163,6 @@ jobs:
           private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Upload Release Asset
-        if: false
         id: upload-release-asset
         uses: svenstaro/upload-release-action@v2
         with:
@@ -178,7 +173,6 @@ jobs:
           overwrite: true
 
   publish_release:
-    if: false
     name: Publish release
     needs: [build_assets, build_linux_assets, build_for_pypi, publish_to_pypi]
     runs-on: ubuntu-latest

--- a/.github/workflows/release_flow.yml
+++ b/.github/workflows/release_flow.yml
@@ -117,30 +117,29 @@ jobs:
 
   build_linux_assets:
     name: Build Linux assets - glibc and musl, arm64 and x86_64
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       matrix:
         include:
           - distro: "alpine:3.14" # alpine 3.14 needed for musl 1.2.2 and python 3.9 compatibility
             arch: arm64
             distro_name: alpine
+            runs-on: ubuntu-24.04-arm
           - distro: "alpine:3.14"
             arch: x86_64
             distro_name: alpine
+            runs-on: ubuntu-24.04
           - distro: "ubuntu:20.04" # ubuntu 20.04 needed for glibc 2.31 and python 3.9 compatibility
             arch: arm64
             distro_name: linux
+            runs-on: ubuntu-24.04-arm
           - distro: "ubuntu:20.04"
             distro_name: linux
             arch: x86_64
+            runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-        with:
-          platforms: ${{ matrix.arch }}
 
       - name: Run in Docker
         run: |

--- a/.github/workflows/release_flow.yml
+++ b/.github/workflows/release_flow.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: pip install uv
 
-      - name: Build sdist and bdist 
+      - name: Build sdist and bdist
         run: |
           cd codecov-cli
           uv build
@@ -35,7 +35,7 @@ jobs:
   publish_to_pypi:
     needs: build_for_pypi
     permissions:
-      id-token: write  # This is required for OIDC
+      id-token: write # This is required for OIDC
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -52,7 +52,6 @@ jobs:
         with:
           verbose: true
           packages-dir: codecov-cli/dist
-
 
   build_assets:
     name: Build packages - ${{ matrix.os }}
@@ -97,6 +96,7 @@ jobs:
         run: cd codecov-cli && ${{matrix.CMD_BUILD}}
 
       - name: Get auth token
+        if: false
         id: token
         uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         with:
@@ -104,6 +104,7 @@ jobs:
           private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Upload Release Asset
+        if: false
         id: upload-release-asset
         uses: svenstaro/upload-release-action@v2
         with:
@@ -119,74 +120,77 @@ jobs:
     strategy:
       matrix:
         include:
-          - distro: "alpine:3.21"
+          - distro: "alpine:3.14" # alpine 3.14 needed for musl 1.2.2 and python 3.9 compatibility
             arch: arm64
             distro_name: alpine
-          - distro: "alpine:3.21"
+          - distro: "alpine:3.14"
             arch: x86_64
             distro_name: alpine
-          - distro: "ubuntu:20.04"
+          - distro: "ubuntu:20.04" # ubuntu 20.04 needed for glibc 2.31 and python 3.9 compatibility
             arch: arm64
             distro_name: linux
-          - distro: "ubuntu:20.04" # 20.04 needed for glibc 2.31 compatibility
+          - distro: "ubuntu:20.04"
             distro_name: linux
             arch: x86_64
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-      with:
-        platforms: ${{ matrix.arch }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: ${{ matrix.arch }}
 
-    - name: Run in Docker
-      run: |
-        docker run \
-          --rm \
-          -v $(pwd):/${{ github.workspace }} \
-          -w ${{ github.workspace }} \
-          --platform linux/${{ matrix.arch }} \
-          ${{ matrix.distro }} \
-          ./codecov-cli/scripts/build_${{ matrix.distro_name }}.sh ${{ matrix.distro_name }}_${{ matrix.arch }}
+      - name: Run in Docker
+        run: |
+          docker run \
+            --rm \
+            -v $(pwd):/${{ github.workspace }} \
+            -w ${{ github.workspace }} \
+            --platform linux/${{ matrix.arch }} \
+            ${{ matrix.distro }} \
+            ./codecov-cli/scripts/build_${{ matrix.distro_name }}.sh ${{ matrix.distro_name }}_${{ matrix.arch }}
 
-    # # Useful for testing
-    # - name: Upload build artifacts
-    #   uses: actions/upload-artifact@v4
-    #   with:
-    #     name: codecovcli_${{ matrix.distro_name }}_${{ matrix.arch }}
-    #     path: ./codecov-cli/dist/codecovcli_*
+      # Useful for testing
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: codecovcli_${{ matrix.distro_name }}_${{ matrix.arch }}
+          path: ./codecov-cli/dist/codecovcli_*
 
-    - name: Get auth token
-      id: token
-      uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
-      with:
-        app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
-        private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
+      - name: Get auth token
+        if: false
+        id: token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        with:
+          app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
 
-    - name: Upload Release Asset
-      id: upload-release-asset
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ steps.token.outputs.token }}
-        file_glob: true
-        file: ./codecov-cli/dist/codecovcli_*
-        tag: ${{ github.ref }}
-        overwrite: true
+      - name: Upload Release Asset
+        if: false
+        id: upload-release-asset
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ steps.token.outputs.token }}
+          file_glob: true
+          file: ./codecov-cli/dist/codecovcli_*
+          tag: ${{ github.ref }}
+          overwrite: true
 
   publish_release:
+    if: false
     name: Publish release
     needs: [build_assets, build_linux_assets, build_for_pypi, publish_to_pypi]
     runs-on: ubuntu-latest
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
     steps:
-      - id: 'auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1.0.0'
+      - id: "auth"
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v1.0.0"
         with:
-          create_credentials_file: 'true'
+          create_credentials_file: "true"
           workload_identity_provider: ${{ secrets.CODECOV_GCP_WIDP }}
           service_account: ${{ secrets.CODECOV_GCP_WIDSA }}
 

--- a/.github/workflows/release_flow.yml
+++ b/.github/workflows/release_flow.yml
@@ -55,7 +55,7 @@ jobs:
           packages-dir: codecov-cli/dist
 
   build_assets:
-    name: Build packages - ${{ matrix.os }}
+    name: Build ${{ matrix.os }} binary
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
@@ -116,7 +116,7 @@ jobs:
           overwrite: true
 
   build_linux_assets:
-    name: Build Linux assets - glibc and musl, arm64 and x86_64
+    name: Build ${{ matrix.distro_name }}_${{ matrix.arch }} binary
     runs-on: ${{ matrix.runs-on }}
     strategy:
       matrix:

--- a/.github/workflows/release_flow.yml
+++ b/.github/workflows/release_flow.yml
@@ -4,14 +4,12 @@ on:
   release:
     types:
       - created
-  push:
 
 permissions:
   contents: read
 
 jobs:
   build_for_pypi:
-    if: false
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -35,7 +33,6 @@ jobs:
           path: ./codecov-cli/dist/*
 
   publish_to_pypi:
-    if: false
     needs: build_for_pypi
     permissions:
       id-token: write # This is required for OIDC
@@ -99,7 +96,6 @@ jobs:
         run: cd codecov-cli && ${{matrix.CMD_BUILD}}
 
       - name: Get auth token
-        if: false
         id: token
         uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         with:
@@ -107,7 +103,6 @@ jobs:
           private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Upload Release Asset
-        if: false
         id: upload-release-asset
         uses: svenstaro/upload-release-action@v2
         with:
@@ -161,7 +156,6 @@ jobs:
       #     path: ./codecov-cli/dist/codecovcli_*
 
       - name: Get auth token
-        if: false
         id: token
         uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         with:
@@ -169,7 +163,6 @@ jobs:
           private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Upload Release Asset
-        if: false
         id: upload-release-asset
         uses: svenstaro/upload-release-action@v2
         with:
@@ -180,7 +173,6 @@ jobs:
           overwrite: true
 
   publish_release:
-    if: false
     name: Publish release
     needs: [build_assets, build_linux_assets, build_for_pypi, publish_to_pypi]
     runs-on: ubuntu-latest

--- a/.github/workflows/release_flow.yml
+++ b/.github/workflows/release_flow.yml
@@ -4,6 +4,7 @@ on:
   release:
     types:
       - created
+  push:
 
 permissions:
   contents: read

--- a/.github/workflows/release_flow.yml
+++ b/.github/workflows/release_flow.yml
@@ -82,10 +82,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.9
         uses: actions/setup-python@v3
         with:
-          python-version: "3.11"
+          python-version: "3.9"
 
       - name: Install dependencies
         run: |

--- a/codecov-cli/scripts/build_alpine.sh
+++ b/codecov-cli/scripts/build_alpine.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 apk add build-base python3 py3-pip
 cd codecov-cli
-pip install --only-binary uv
+pip install uv --prefer-binary
 uv sync
 uv add --dev pyinstaller
 uv run pyinstaller -F codecov_cli/main.py

--- a/codecov-cli/scripts/build_alpine.sh
+++ b/codecov-cli/scripts/build_alpine.sh
@@ -2,10 +2,9 @@
 apk add build-base python3 py3-pip curl
 curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.7.8/uv-installer.sh > uv-installer.sh
 # Added sanity check file has not been tampered with
-if [[ $(sha256sum uv-installer.sh) == "3e3043ca08e1156fbe18d90a1a4def3ae795418857c8f4ed3f807ffc45e51c3d  uv-installer.sh" ]]; then
-    
-    chmod +x uv-installer.sh
-    ./uv-installer.sh
+echo "3e3043ca08e1156fbe18d90a1a4def3ae795418857c8f4ed3f807ffc45e51c3d  uv-installer.sh" > uv-installer.sh.SHA256SUM
+if sha256sum -c uv-installer.sh.SHA256SUM; then
+    sh uv-installer.sh
 fi
 cd codecov-cli
 /root/.local/bin/uv python pin 3.9

--- a/codecov-cli/scripts/build_alpine.sh
+++ b/codecov-cli/scripts/build_alpine.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 apk add build-base python3 py3-pip
 cd codecov-cli
-pip install uv --break-system-packages
+pip install uv
 uv sync
 uv add --dev pyinstaller
 uv run pyinstaller -F codecov_cli/main.py

--- a/codecov-cli/scripts/build_alpine.sh
+++ b/codecov-cli/scripts/build_alpine.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-apk add build-base python3 py3-pip
+apk add build-base python3 py3-pip curl
 curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.7.8/uv-installer.sh
 # Added sanity check file has not been tampered with
 if [[ $(sha256sum uv-installer.sh) == "3e3043ca08e1156fbe18d90a1a4def3ae795418857c8f4ed3f807ffc45e51c3d  uv-installer.sh" ]]; then

--- a/codecov-cli/scripts/build_alpine.sh
+++ b/codecov-cli/scripts/build_alpine.sh
@@ -2,12 +2,11 @@
 apk add build-base python3 py3-pip curl
 curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.7.8/uv-installer.sh > uv-installer.sh
 # Added sanity check file has not been tampered with
-echo "3e3043ca08e1156fbe18d90a1a4def3ae795418857c8f4ed3f807ffc45e51c3d  uv-installer.sh" > uv-installer.sh.SHA256SUM
-if sha256sum -c uv-installer.sh.SHA256SUM; then
+if sha256sum -c ./codecov-cli/scripts/uv-installer-0.7.8.sha256sum; then
     sh uv-installer.sh
 fi
 cd codecov-cli
-/root/.local/bin/uv python pin 3.9
+/root/.local/bin/uv python pin 3.9 # we need to build with python 3.9 to support systems with libpython >= 3.9
 /root/.local/bin/uv sync
 /root/.local/bin/uv add --dev pyinstaller
 /root/.local/bin/uv run pyinstaller -F codecov_cli/main.py

--- a/codecov-cli/scripts/build_alpine.sh
+++ b/codecov-cli/scripts/build_alpine.sh
@@ -1,9 +1,14 @@
 #!/bin/sh
 apk add build-base python3 py3-pip
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.7.8/uv-installer.sh
+# Added sanity check file has not been tampered with
+if [[ $(sha256sum uv-installer.sh) == "3e3043ca08e1156fbe18d90a1a4def3ae795418857c8f4ed3f807ffc45e51c3d  uv-installer.sh" ]]; then
+    
+    sh uv-installer.sh
+fi
 cd codecov-cli
-python3.9 -m pip install uv
-uv python pin 3.9
-uv sync
-uv add --dev pyinstaller
-uv run pyinstaller -F codecov_cli/main.py
+/root/.local/bin/uv python pin 3.9
+/root/.local/bin/uv sync
+/root/.local/bin/uv add --dev pyinstaller
+/root/.local/bin/uv run pyinstaller -F codecov_cli/main.py
 mv ./dist/main ./dist/codecovcli_$1

--- a/codecov-cli/scripts/build_alpine.sh
+++ b/codecov-cli/scripts/build_alpine.sh
@@ -4,7 +4,8 @@ curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/d
 # Added sanity check file has not been tampered with
 if [[ $(sha256sum uv-installer.sh) == "3e3043ca08e1156fbe18d90a1a4def3ae795418857c8f4ed3f807ffc45e51c3d  uv-installer.sh" ]]; then
     
-    sh uv-installer.sh
+    chmod +x uv-installer.sh
+    ./uv-installer.sh
 fi
 cd codecov-cli
 /root/.local/bin/uv python pin 3.9

--- a/codecov-cli/scripts/build_alpine.sh
+++ b/codecov-cli/scripts/build_alpine.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 apk add build-base python3 py3-pip
 cd codecov-cli
-pip install uv --prefer-binary
+python3.9 -m pip install uv
+uv python pin 3.9
 uv sync
 uv add --dev pyinstaller
 uv run pyinstaller -F codecov_cli/main.py

--- a/codecov-cli/scripts/build_alpine.sh
+++ b/codecov-cli/scripts/build_alpine.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 apk add build-base python3 py3-pip
 cd codecov-cli
-pip install uv
+pip install --only-binary uv
 uv sync
 uv add --dev pyinstaller
 uv run pyinstaller -F codecov_cli/main.py

--- a/codecov-cli/scripts/build_alpine.sh
+++ b/codecov-cli/scripts/build_alpine.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 apk add build-base python3 py3-pip curl
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.7.8/uv-installer.sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.7.8/uv-installer.sh > uv-installer.sh
 # Added sanity check file has not been tampered with
 if [[ $(sha256sum uv-installer.sh) == "3e3043ca08e1156fbe18d90a1a4def3ae795418857c8f4ed3f807ffc45e51c3d  uv-installer.sh" ]]; then
     

--- a/codecov-cli/scripts/build_linux.sh
+++ b/codecov-cli/scripts/build_linux.sh
@@ -3,7 +3,7 @@ apt update
 DEBIAN_FRONTEND=noninteractive apt install -y tzdata
 apt install -y python3.9 python3.9-dev python3-pip
 cd codecov-cli
-python3.9 -m pip install uv
+python3.9 -m pip install uv --only-binary uv
 uv python pin 3.9
 uv sync
 uv add --dev pyinstaller

--- a/codecov-cli/scripts/build_linux.sh
+++ b/codecov-cli/scripts/build_linux.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 apt update
+DEBIAN_FRONTEND=noninteractive apt install -y tzdata
 apt install -y python3.9 python3.9-dev python3-pip
 cd codecov-cli
 python3.9 -m pip install uv

--- a/codecov-cli/scripts/build_linux.sh
+++ b/codecov-cli/scripts/build_linux.sh
@@ -3,7 +3,7 @@ apt update
 DEBIAN_FRONTEND=noninteractive apt install -y tzdata
 apt install -y python3.9 python3.9-dev python3-pip
 cd codecov-cli
-python3.9 -m pip install --only-binary uv
+python3.9 -m pip install uv
 uv python pin 3.9
 uv sync
 uv add --dev pyinstaller

--- a/codecov-cli/scripts/build_linux.sh
+++ b/codecov-cli/scripts/build_linux.sh
@@ -4,7 +4,7 @@ DEBIAN_FRONTEND=noninteractive apt install -y tzdata
 apt install -y python3.9 python3.9-dev python3-pip
 cd codecov-cli
 python3.9 -m pip install uv --only-binary uv
-uv python pin 3.9
+uv python pin 3.9 # we need to build with python 3.9 to support systems with libpython >= 3.9
 uv sync
 uv add --dev pyinstaller
 uv run pyinstaller -F codecov_cli/main.py

--- a/codecov-cli/scripts/build_linux.sh
+++ b/codecov-cli/scripts/build_linux.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 apt update
-apt install -y build-essential python3 python3-pip
+apt install -y python3.9 python3.9-dev python3-pip
 cd codecov-cli
-pip install uv
+python3.9 -m pip install uv
+uv python pin 3.9
 uv sync
 uv add --dev pyinstaller
 uv run pyinstaller -F codecov_cli/main.py

--- a/codecov-cli/scripts/build_linux.sh
+++ b/codecov-cli/scripts/build_linux.sh
@@ -3,7 +3,7 @@ apt update
 DEBIAN_FRONTEND=noninteractive apt install -y tzdata
 apt install -y python3.9 python3.9-dev python3-pip
 cd codecov-cli
-python3.9 -m pip install uv
+python3.9 -m pip install --only-binary uv
 uv python pin 3.9
 uv sync
 uv add --dev pyinstaller

--- a/codecov-cli/scripts/uv-installer-0.7.8.sha256sum
+++ b/codecov-cli/scripts/uv-installer-0.7.8.sha256sum
@@ -1,0 +1,1 @@
+3e3043ca08e1156fbe18d90a1a4def3ae795418857c8f4ed3f807ffc45e51c3d  uv-installer.sh


### PR DESCRIPTION
- Ensures build happens on python 3.9
- Builds arm binaries natively on new arm runner versus qemu emulation (big time save woo)
- Downgrades alpine build env to 3.14 for best compatibility with musl