### PR TITLE
ci(release): Fix command to get previous release version

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -25,7 +25,7 @@ jobs:
         name: Configure Release Vars
         run: |
           release_version=v$(grep -E "version = \"[0-9]+\.[0-9]+\.[0-9]+\"" codecov-cli/pyproject.toml | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+")
-          previous_version=$(git tag --sort=-creatordate | head -n 2 | tail -n 1)
+          previous_version=$(git tag --sort=-creatordate | head -n 1) # The most recent tag (since the tag for the new release has not yet been created)
           echo "release_version=$release_version"
           echo "previous_version=$previous_version"
 


### PR DESCRIPTION
Fixes the comparison tag for new releases. Resolves #47.