### PR TITLE
feat: create new upload command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,5 +114,6 @@ jobs:
       - name: Dogfooding sentry-prevent-cli
         if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'getsentry' }}
         run: |
-          uv run --project prevent-cli sentry-prevent-cli -v do-upload --fail-on-error -t ${{ secrets.CODECOV_TOKEN }} --plugin pycoverage --flag python${{matrix.python-version}} --flag sentry-prevent-cli
-          uv run --project prevent-cli sentry-prevent-cli do-upload --report-type test_results --fail-on-error -t ${{ secrets.CODECOV_TOKEN }} --plugin pycoverage --flag python${{matrix.python-version}} --flag sentry-prevent-cli
+          uv run --project prevent-cli sentry-prevent-cli upload --fail-on-error -t ${{ secrets.CODECOV_TOKEN }} --plugin pycoverage --flag python${{matrix.python-version}} --flag sentry-prevent-cli
+          uv run --project prevent-cli sentry-prevent-cli upload --report-type test_results --fail-on-error -t ${{ secrets.CODECOV_TOKEN }} --plugin pycoverage --flag python${{matrix.python-version}} --flag sentry-prevent-cli
+          uv run --project prevent-cli sentry-prevent-cli upload --report-type test-results --fail-on-error -t ${{ secrets.CODECOV_TOKEN }} --plugin pycoverage --flag python${{matrix.python-version}} --flag sentry-prevent-cli

--- a/codecov-cli/codecov_cli/helpers/upload_type.py
+++ b/codecov-cli/codecov_cli/helpers/upload_type.py
@@ -9,7 +9,7 @@ class ReportType(Enum):
 def report_type_from_str(report_type_str: str) -> ReportType:
     if report_type_str == "coverage":
         return ReportType.COVERAGE
-    elif report_type_str == "test_results":
+    elif report_type_str.replace("-", "_") == "test_results":
         return ReportType.TEST_RESULTS
     else:
         raise ValueError(f"Invalid upload type: {report_type_str}")

--- a/prevent-cli/preventcli_commands
+++ b/prevent-cli/preventcli_commands
@@ -18,6 +18,7 @@ Commands:
   pr-base-picking
   process-test-results
   send-notifications
+  upload
   upload-coverage
   upload-process
 
@@ -187,6 +188,78 @@ Options:
   -t, --token TEXT                Codecov upload token
   -r, --slug TEXT                 owner/repo slug used instead of the private
                                   repo token in Self-hosted
+  -h, --help                      Show this message and exit.
+
+Usage: sentry-prevent-cli upload [OPTIONS]
+
+Options:
+  -C, --sha, --commit-sha TEXT    Commit SHA (with 40 chars)  [required]
+  -Z, --fail-on-error             Exit with non-zero code in case of error
+  --git-service [github|gitlab|bitbucket|github_enterprise|gitlab_enterprise|bitbucket_server]
+  -t, --token TEXT                Codecov upload token
+  -r, --slug TEXT                 owner/repo slug used instead of the private
+                                  repo token in Self-hosted
+  --network-root-folder PATH      Root folder from which to consider paths on
+                                  the network section  [default: (Current
+                                  working directory)]
+  -s, --dir, --coverage-files-search-root-folder, --files-search-root-folder PATH
+                                  Folder where to search for coverage files
+                                  [default: (Current Working Directory)]
+  --exclude, --coverage-files-search-exclude-folder, --files-search-exclude-folder PATH
+                                  Folders to exclude from search
+  -f, --file, --coverage-files-search-direct-file, --files-search-direct-file PATH
+                                  Explicit files to upload. These will be
+                                  added to the coverage files found for
+                                  upload. If you wish to only upload the
+                                  specified files, please consider using
+                                  --disable-search to disable uploading other
+                                  files.
+  --recurse-submodules            Whether to enumerate files inside of
+                                  submodules for path-fixing purposes. Off by
+                                  default.
+  --disable-search                Disable search for coverage files. This is
+                                  helpful when specifying what files you want
+                                  to upload with the --file option.
+  --disable-file-fixes            Disable file fixes to ignore common lines
+                                  from coverage (e.g. blank lines or empty
+                                  brackets)
+  -b, --build, --build-code TEXT  Specify the build number manually
+  --build-url TEXT                The URL of the build where this is running
+  --job-code TEXT
+  -n, --name TEXT                 Custom defined name of the upload. Visible
+                                  in Codecov UI
+  -B, --branch TEXT               Branch to which this commit belongs to
+  -P, --pr, --pull-request-number TEXT
+                                  Specify the pull request number manually.
+                                  Used to override pre-existing CI environment
+                                  variables
+  -e, --env, --env-var TEXT       Specify environment variables to be included
+                                  with this build.
+  -F, --flag TEXT                 Flag the upload to group coverage metrics.
+                                  Multiple flags allowed.
+  --plugin TEXT
+  -d, --dry-run                   Don't upload files to Codecov
+  --legacy, --use-legacy-uploader
+                                  Use the legacy upload endpoint
+  --handle-no-reports-found       Raise no exceptions when no coverage reports
+                                  found.
+  --report-type [coverage|test-results]
+                                  The type of report to upload
+  --network-filter TEXT           Specify a filter on the files listed in the
+                                  network section of the Codecov report. This
+                                  will only add files whose path begin with
+                                  the specified filter. Useful for upload-
+                                  specific path fixing
+  --network-prefix TEXT           Specify a prefix on files listed in the
+                                  network section of the Codecov report.
+                                  Useful to help resolve path fixing
+  --gcov-args TEXT                Extra arguments to pass to gcov
+  --gcov-ignore TEXT              Paths to ignore during gcov gathering
+  --gcov-include TEXT             Paths to include during gcov gathering
+  --gcov-executable TEXT          gcov executable to run. Defaults to 'gcov'
+  --swift-project TEXT            Specify the swift project
+  --parent-sha TEXT               SHA (with 40 chars) of what should be the
+                                  parent of this commit
   -h, --help                      Show this message and exit.
 
 Usage: sentry-prevent-cli upload-coverage [OPTIONS]

--- a/prevent-cli/preventcli_commands
+++ b/prevent-cli/preventcli_commands
@@ -243,7 +243,7 @@ Options:
                                   Use the legacy upload endpoint
   --handle-no-reports-found       Raise no exceptions when no coverage reports
                                   found.
-  --report-type [coverage|test-results]
+  --report-type [coverage|test-results|test_results]
                                   The type of report to upload
   --network-filter TEXT           Specify a filter on the files listed in the
                                   network section of the Codecov report. This

--- a/prevent-cli/src/prevent_cli/main.py
+++ b/prevent-cli/src/prevent_cli/main.py
@@ -88,16 +88,14 @@ def cli(
 
 upload = deepcopy(upload_coverage)
 upload.name = "upload"
-upload.context_settings = {
-    "token_normalize_func": lambda x: x.replace("test_results", "test-results")
-}
+
 for i, param in enumerate(upload.params):
     if param.name == "report_type_str":
         upload.params[i] = click.Option(
             ("--report-type", "report_type_str"),
             help="The type of report to upload",
             default="coverage",
-            type=click.Choice(["coverage", "test-results"]),
+            type=click.Choice(["coverage", "test-results", "test_results"]),
         )
         break
 

--- a/prevent-cli/src/prevent_cli/main.py
+++ b/prevent-cli/src/prevent_cli/main.py
@@ -1,6 +1,7 @@
 import logging
 import pathlib
 import typing
+from copy import deepcopy
 
 import click
 from codecov_cli import __version__
@@ -85,12 +86,27 @@ def cli(
     init_telem(ctx.obj)
 
 
+upload = deepcopy(upload_coverage)
+upload.name = "upload"
+upload.context_settings = {"token_normalize_func": lambda x: x.replace("_", "-")}
+for i, param in enumerate(upload.params):
+    if param.name == "report_type_str":
+        upload.params[i] = click.Option(
+            ("--report-type", "report_type_str"),
+            help="The type of report to upload",
+            default="coverage",
+            type=click.Choice(["coverage", "test-results"]),
+        )
+        break
+
+
 cli.add_command(do_upload)
 cli.add_command(create_commit)
 cli.add_command(create_report)
 cli.add_command(pr_base_picking)
 cli.add_command(empty_upload)
 cli.add_command(upload_coverage)
+cli.add_command(upload)
 cli.add_command(upload_process)
 cli.add_command(send_notifications)
 cli.add_command(process_test_results)

--- a/prevent-cli/src/prevent_cli/main.py
+++ b/prevent-cli/src/prevent_cli/main.py
@@ -88,7 +88,9 @@ def cli(
 
 upload = deepcopy(upload_coverage)
 upload.name = "upload"
-upload.context_settings = {"token_normalize_func": lambda x: x.replace("_", "-")}
+upload.context_settings = {
+    "token_normalize_func": lambda x: x.replace("test_results", "test-results")
+}
 for i, param in enumerate(upload.params):
     if param.name == "report_type_str":
         upload.params[i] = click.Option(


### PR DESCRIPTION
Fixes CCMRG-1362
Fixes CCMRG-1361


we wanted to have a simplified interface so we're going to create a new "upload" command.

This command is just a copy of upload-coverage but obviously with a diffrent name and it also accepts `test-results` alongside `test_results` for the "--report-type" option