### PR TITLE
fix: macos build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,8 @@ name: Build and publish codecov-cli
 
 on:
   push:
-    branches:
-      - "release/**"
+    # branches:
+    #   - "release/**"
 
 permissions:
   contents: read
@@ -53,7 +53,7 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - os: macos-13
+          - os: macos-14
             TARGET: macos
             CMD_BUILD: >
               cd ./codecov-cli &&

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,8 @@ name: Build and publish codecov-cli
 
 on:
   push:
-    # branches:
-    #   - "release/**"
+    branches:
+      - "release/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
Went down to oldest macos image, but that seems to break things. Now on macos 14. This may cause incompatibility for macos < 14, but we build on macos 14 today so won't break any existing installs.