### PR TITLE
fix: Craft try removing requireNames

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -4,15 +4,6 @@ github:
 
 changelogPolicy: auto
 
-requireNames:
-  - sentry-prevent-cli_wheel
-  - sentry-prevent-cli_alpine_arm64
-  - sentry-prevent-cli_alpine_x86_64
-  - sentry-prevent-cli_linux_arm64
-  - sentry-prevent-cli_linux_x86_64
-  - sentry-prevent-cli_macos
-  - sentry-prevent-cli_windows.exe
-
 targets:
   # For direct binary downloads + shasum + shasum.sig
   - name: github


### PR DESCRIPTION
Attempt to fix https://github.com/getsentry/publish/actions/runs/16477839341/job/46584077003

current best guess is that it was looking for these but wasn't hitting or something. They shouldn't be necessary anyway.