### PR TITLE
fix: Add support for Kover test coverage reports for Android variants

### DIFF
--- a/codecov-cli/codecov_cli/services/upload/file_finder.py
+++ b/codecov-cli/codecov_cli/services/upload/file_finder.py
@@ -35,7 +35,7 @@ coverage_files_patterns = [
     "luacov.report.out",
     "naxsi.info",
     "nosetests.xml",
-    "report.xml",
+    "report*.xml",
     "test_cov.xml",
 ]
 

--- a/codecov-cli/tests/services/upload/test_coverage_file_finder.py
+++ b/codecov-cli/tests/services/upload/test_coverage_file_finder.py
@@ -61,6 +61,8 @@ class TestCoverageFileFinder(object):
             "abc.gcov",
             "sub/abc.gcov",
             "sub/subsub/abc.gcov",
+            "report.xml",
+            "sub/reportDebug.xml",
         ]
 
         should_ignore = [


### PR DESCRIPTION
Updates the rule for `report.xml` to `report*.xml` to allow for Android based Kover tests to be eagerly found by the CodeCov CLI.

fixes #82