### PR TITLE
build: pin click version to correct version

### DIFF
--- a/codecov-cli/pyproject.toml
+++ b/codecov-cli/pyproject.toml
@@ -12,7 +12,7 @@ maintainers = [
 ]
 requires-python = ">= 3.9"
 dependencies = [
-    "click==8.*",
+    "click>=8.0.0,<8.3.0",
     "ijson==3.*",
     "PyYAML==6.*",
     "responses==0.21.*",

--- a/prevent-cli/pyproject.toml
+++ b/prevent-cli/pyproject.toml
@@ -9,7 +9,7 @@ authors = [{ name = "Sentry", email = "oss@sentry.io" }]
 requires-python = ">=3.9"
 dependencies = [
     "codecov-cli==11.2.2",
-    "click==8.*",
+    "click>=8.0.0,<8.3.0",
     "sentry-sdk==2.*",
 ]
 


### PR DESCRIPTION
I manually tested that 8.3.0 is causing the commit sha not found cli issue so i'm manually pinning the version to avoid that for now. not sure what the root cause is, just treating the symptom that 8.3 breaks things for now. See previous commits on this PRs' CI runs for the proof that 8.3 is broken