### PR TITLE
fix: Add missing f string in swiftcov func of xcode plugin

### DIFF
--- a/codecov-cli/codecov_cli/plugins/xcode.py
+++ b/codecov-cli/codecov_cli/plugins/xcode.py
@@ -90,7 +90,7 @@ class XcodePlugin(object):
                     dest = (
                         proj_path
                         if proj_path.is_file()
-                        else dir_path / "Contents/MacOS/{proj}"
+                        else dir_path / f"Contents/MacOS/{proj}"
                     )
                     output_file_name = f"{proj}.{type}.coverage.txt".replace(" ", "")
                     self.run_llvm_cov(output_file_name, path, dest)


### PR DESCRIPTION
Fixes code coverage generation for some swift projects, currently looks like this:

```sh
==> Running upload-coverage
      ./codecov  upload-coverage -t <redacted> --git-service github --gcov-executable gcov
info - 2025-09-18 21:10:08,461 -- ci service found: github-actions
info - 2025-09-18 21:10:08,620 -- Running swift coverage on the following list of files: --- {"matched_paths": ["/Users/runner/Library/Developer/Xcode/DerivedData/ChromaSwift-gtzsdaclinjizxegjyiqrvlbelap/Build/ProfileData/2823e84cf20da531196b91b0539218db7086d1c7/Coverage.profdata"]}
info - 2025-09-18 21:10:08,625 -- + Building reports for CChromaprintTests xctest
error: failed to load coverage: '/Users/runner/Library/Developer/Xcode/DerivedData/ChromaSwift-gtzsdaclinjizxegjyiqrvlbelap/Build/Products/Debug/CChromaprintTests.xctest/Contents/MacOS/{proj}': No such file or directory
warning - 2025-09-18 21:10:09,877 -- llvm-cov failed to produce results for /Users/runner/Library/Developer/Xcode/DerivedData/ChromaSwift-gtzsdaclinjizxegjyiqrvlbelap/Build/Products/Debug/CChromaprintTests.xctest/Contents/MacOS/{proj}
```