### PR TITLE
feat: Clarify upload queueing logging and process completion logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ lint:
 	make lint.install
 	make lint.run
 
+test:
+	cd codecov-cli && uv run pytest
+
 command_dump:
 	cd prevent-cli && uv run command_dump.py
 

--- a/codecov-cli/codecov_cli/helpers/request.py
+++ b/codecov-cli/codecov_cli/helpers/request.py
@@ -152,7 +152,7 @@ def log_warnings_and_errors_if_any(
     sending_result: RequestResult, process_desc: str, fail_on_error: bool = False
 ):
     logger.info(
-        f"Process {process_desc} complete",
+        f"{process_desc} complete",
     )
     logger.debug(
         f"{process_desc} result",

--- a/codecov-cli/codecov_cli/services/upload/__init__.py
+++ b/codecov-cli/codecov_cli/services/upload/__init__.py
@@ -165,5 +165,5 @@ def do_upload_logic(
             status_code=200,
             text="Data NOT sent to Codecov because of dry-run option",
         )
-    log_warnings_and_errors_if_any(sending_result, "Upload", fail_on_error)
+    log_warnings_and_errors_if_any(sending_result, "Upload queued for processing", fail_on_error)
     return sending_result

--- a/codecov-cli/codecov_cli/services/upload/upload_sender.py
+++ b/codecov-cli/codecov_cli/services/upload/upload_sender.py
@@ -117,7 +117,7 @@ class UploadSender(object):
                 resp_json_obj = json.loads(resp_from_codecov.text)
                 if resp_json_obj.get("url"):
                     logger.info(
-                        f"Your upload is now processing. When finished, results will be available at: {resp_json_obj.get('url')}"
+                        f"Your upload is now queued for processing. When finished, results will be available at: {resp_json_obj.get('url')}"
                     )
                 logger.debug(
                     "Upload request to Codecov complete.",

--- a/codecov-cli/tests/commands/test_invoke_upload.py
+++ b/codecov-cli/tests/commands/test_invoke_upload.py
@@ -40,7 +40,7 @@ def test_upload_raise_Z_option(mocker):
     result = runner.invoke(cli, ["do-upload", "--fail-on-error"], obj={})
     upload_sender.assert_called()
     upload_collector.assert_called()
-    assert ("error", "Upload failed: Unauthorized") in parse_outstreams_into_log_lines(
+    assert ("error", "Upload queued for processing failed: Unauthorized") in parse_outstreams_into_log_lines(
         result.output
     )
     assert str(result) == "<Result SystemExit(1)>"

--- a/codecov-cli/tests/services/commit/test_commit_service.py
+++ b/codecov-cli/tests/services/commit/test_commit_service.py
@@ -31,7 +31,7 @@ def test_commit_command_with_warnings(mocker):
 
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
-        ("info", "Process Commit creating complete"),
+        ("info", "Commit creating complete"),
         ("info", "Commit creating process had 1 warning"),
         ("warning", "Warning 1: somewarningmessage"),
     ]
@@ -81,7 +81,7 @@ def test_commit_command_with_error(mocker):
     assert out_bytes == [
         (
             "info",
-            "Process Commit creating complete",
+            "Commit creating complete",
         ),
         ("error", "Commit creating failed: Permission denied"),
     ]

--- a/codecov-cli/tests/services/empty_upload/test_empty_upload.py
+++ b/codecov-cli/tests/services/empty_upload/test_empty_upload.py
@@ -34,7 +34,7 @@ def test_empty_upload_with_warnings(mocker):
         )
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
-        ("info", "Process Empty Upload complete"),
+        ("info", "Empty Upload complete"),
         ("info", "Empty Upload process had 1 warning"),
         ("warning", "Warning 1: somewarningmessage"),
     ]
@@ -71,7 +71,7 @@ def test_empty_upload_with_error(mocker):
 
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
-        ("info", "Process Empty Upload complete"),
+        ("info", "Empty Upload complete"),
         ("error", "Empty Upload failed: Permission denied"),
     ]
     assert res == mock_send_commit_data.return_value
@@ -97,7 +97,7 @@ def test_empty_upload_200(mocker):
         )
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
-        ("info", "Process Empty Upload complete"),
+        ("info", "Empty Upload complete"),
         ("info", "All changed files are ignored. Triggering passing notifications."),
         ("info", "Non ignored files []"),
     ]
@@ -142,7 +142,7 @@ def test_empty_upload_force(mocker):
         )
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
-        ("info", "Process Empty Upload complete"),
+        ("info", "Empty Upload complete"),
         ("info", "Force option was enabled. Triggering passing notifications."),
         ("info", "Non ignored files []"),
     ]
@@ -170,7 +170,7 @@ def test_empty_upload_no_token(mocker):
 
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
-        ("info", "Process Empty Upload complete"),
+        ("info", "Empty Upload complete"),
         ("info", "All changed files are ignored. Triggering passing notifications."),
         ("info", "Non ignored files []"),
     ]

--- a/codecov-cli/tests/services/report/test_report_results.py
+++ b/codecov-cli/tests/services/report/test_report_results.py
@@ -36,7 +36,7 @@ def test_report_results_command_with_warnings(mocker):
 
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
-        ("info", "Process Report results creating complete"),
+        ("info", "Report results creating complete"),
         ("info", "Report results creating process had 1 warning"),
         ("warning", "Warning 1: somewarningmessage"),
     ]
@@ -81,7 +81,7 @@ def test_report_results_command_with_error(mocker):
 
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
-        ("info", "Process Report results creating complete"),
+        ("info", "Report results creating complete"),
         ("error", "Report results creating failed: Permission denied"),
     ]
     assert res == mock_send_reports_result_request.return_value

--- a/codecov-cli/tests/services/report/test_report_service.py
+++ b/codecov-cli/tests/services/report/test_report_service.py
@@ -87,7 +87,7 @@ def test_create_report_command_with_warnings(mocker):
 
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
-        ("info", "Process Report creating complete"),
+        ("info", "Report creating complete"),
         ("info", "Report creating process had 1 warning"),
         ("warning", "Warning 1: somewarningmessage"),
     ]
@@ -130,7 +130,7 @@ def test_create_report_command_with_error(mocker):
 
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
-        ("info", "Process Report creating complete"),
+        ("info", "Report creating complete"),
         ("error", "Report creating failed: Permission denied"),
     ]
     assert res == RequestResult(

--- a/codecov-cli/tests/services/upload/test_upload_service.py
+++ b/codecov-cli/tests/services/upload/test_upload_service.py
@@ -80,8 +80,8 @@ def test_do_upload_logic_happy_path_legacy_uploader(mocker):
         )
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
-        ("info", "Process Upload complete"),
-        ("info", "Upload process had 1 warning"),
+        ("info", "Upload queued for processing complete"),
+        ("info", "Upload queued for processing process had 1 warning"),
         ("warning", "Warning 1: somewarningmessage"),
     ]
 
@@ -195,8 +195,8 @@ def test_do_upload_logic_happy_path(mocker):
         )
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
-        ("info", "Process Upload complete"),
-        ("info", "Upload process had 1 warning"),
+        ("info", "Upload queued for processing complete"),
+        ("info", "Upload queued for processing process had 1 warning"),
         ("warning", "Warning 1: somewarningmessage"),
     ]
 
@@ -333,7 +333,7 @@ def test_do_upload_logic_dry_run(mocker):
     )
     assert out_bytes == [
         ("info", "dry-run option activated. NOT sending data to Codecov."),
-        ("info", "Process Upload complete"),
+        ("info", "Upload queued for processing complete"),
     ]
     assert res == RequestResult(
         error=None,
@@ -399,10 +399,10 @@ def test_do_upload_logic_verbose(mocker, use_verbose_option):
             "Selected uploader to use: <class 'codecov_cli.services.upload.legacy_upload_sender.LegacyUploadSender'>",
         ),
         ("info", "dry-run option activated. NOT sending data to Codecov."),
-        ("info", "Process Upload complete"),
+        ("info", "Upload queued for processing complete"),
         (
             "debug",
-            'Upload result --- {"result": "RequestResult(error=None, warnings=None, status_code=200, text=\'Data NOT sent to Codecov because of dry-run option\')"}',
+            'Upload queued for processing result --- {"result": "RequestResult(error=None, warnings=None, status_code=200, text=\'Data NOT sent to Codecov because of dry-run option\')"}',
         ),
     ]
     assert res == RequestResult(
@@ -671,8 +671,8 @@ def test_do_upload_logic_happy_path_test_results(mocker):
         )
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
-        ("info", "Process Upload complete"),
-        ("info", "Upload process had 1 warning"),
+        ("info", "Upload queued for processing complete"),
+        ("info", "Upload queued for processing process had 1 warning"),
         ("warning", "Warning 1: somewarningmessage"),
     ]
 

--- a/codecov-cli/tests/services/upload_completion/test_upload_completion.py
+++ b/codecov-cli/tests/services/upload_completion/test_upload_completion.py
@@ -27,7 +27,7 @@ def test_upload_completion_with_warnings(mocker):
         )
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
-        ("info", "Process Upload Completion complete"),
+        ("info", "Upload Completion complete"),
         ("info", "Upload Completion process had 1 warning"),
         ("warning", "Warning 1: somewarningmessage"),
     ]
@@ -56,7 +56,7 @@ def test_upload_completion_with_error(mocker):
         )
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
-        ("info", "Process Upload Completion complete"),
+        ("info", "Upload Completion complete"),
         ("error", "Upload Completion failed: Permission denied"),
     ]
     assert res == mock_send_commit_data.return_value
@@ -84,7 +84,7 @@ def test_upload_completion_200(mocker):
         )
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
-        ("info", "Process Upload Completion complete"),
+        ("info", "Upload Completion complete"),
         (
             "info",
             "{'uploads_total': 2, 'uploads_success': 2, 'uploads_processing': 0, 'uploads_error': 0}",
@@ -113,7 +113,7 @@ def test_upload_completion_no_token(mocker):
         res = upload_completion_logic("commit_sha", "owner/repo", None, "service", None)
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
-        ("info", "Process Upload Completion complete"),
+        ("info", "Upload Completion complete"),
         (
             "info",
             "{'uploads_total': 2, 'uploads_success': 2, 'uploads_processing': 0, 'uploads_error': 0}",


### PR DESCRIPTION
Closes https://github.com/getsentry/prevent-cli/issues/74

The language was confusing for users so I:
- modified the "Upload" process wording
- removed the word "Process" that came before the process description for all of the processes as it seemed a bit redundant

For reference, the existing options we have for `process_desc` are
"Upload" -> "Upload queued for processing"
"Empty Upload"
"Commit creating"
"Base picking"
"Report creating"
"Report results creating"
"Getting report results"
"Upload Completion"
"Posting test results comment".