### PR TITLE
fix: sample high-volume "Token required" Sentry errors at 1%

### DIFF
--- a/codecov-cli/codecov_cli/opentelemetry.py
+++ b/codecov-cli/codecov_cli/opentelemetry.py
@@ -13,13 +13,20 @@ _SAMPLE_RATE = 100
 
 
 def _before_send(event, hint):
-    text = " ".join(filter(None, [
-        (event.get("logentry") or {}).get("message"),
-        event.get("message"),
-        *[e.get("value") for e in (event.get("exception") or {}).get("values", [])],
-    ]))
-    if any(p in text for p in _SAMPLED_MESSAGES) and random.randint(1, _SAMPLE_RATE) != 1:
-        return None
+    messages = []
+    if "message" in event:
+        messages.append(event.get("message"))
+    if "logentry" in event and "message" in event.get("logentry"):
+        messages.append(event.get("logentry").get("message"))
+    for exc in (event.get("exception", {})).get("values", []):
+        if "value" in exc:
+            messages.append(exc.get("value"))
+
+    for message in messages:
+        for pattern in _SAMPLED_MESSAGES:
+            if pattern in message and random.randint(1, _SAMPLE_RATE) != 1:
+                return None
+
     return event
 
 

--- a/codecov-cli/codecov_cli/opentelemetry.py
+++ b/codecov-cli/codecov_cli/opentelemetry.py
@@ -12,26 +12,14 @@ _SAMPLED_MESSAGES = [
 _SAMPLE_RATE = 100
 
 
-def _collect_messages(event):
-    msg = (event.get("logentry") or {}).get("message", "")
-    if msg:
-        yield msg
-    msg = event.get("message", "")
-    if msg:
-        yield msg
-    for exc in (event.get("exception") or {}).get("values", []):
-        val = exc.get("value", "")
-        if val:
-            yield val
-
-
 def _before_send(event, hint):
-    for message in _collect_messages(event):
-        for pattern in _SAMPLED_MESSAGES:
-            if pattern in message:
-                if random.randint(1, _SAMPLE_RATE) != 1:
-                    return None
-                return event
+    text = " ".join(filter(None, [
+        (event.get("logentry") or {}).get("message"),
+        event.get("message"),
+        *[e.get("value") for e in (event.get("exception") or {}).get("values", [])],
+    ]))
+    if any(p in text for p in _SAMPLED_MESSAGES) and random.randint(1, _SAMPLE_RATE) != 1:
+        return None
     return event
 
 

--- a/codecov-cli/codecov_cli/opentelemetry.py
+++ b/codecov-cli/codecov_cli/opentelemetry.py
@@ -5,22 +5,23 @@ import sentry_sdk
 
 from codecov_cli import __version__
 
-_SKIP_TAG_KEYS = {"branch", "flags", "commit_sha", "env_vars"}
 _SAMPLED_MESSAGES = [
     "Token required",
 ]
 _SAMPLE_RATE = 100
+_SKIP_TAG_KEYS = {"branch", "flags", "commit_sha", "env_vars"}
 
 
 def _before_send(event, hint):
     messages = []
-    if "message" in event:
+    if "message" in event and event.get("message") is not None:
         messages.append(event.get("message"))
-    if "logentry" in event and "message" in event.get("logentry"):
-        messages.append(event.get("logentry").get("message"))
-    for exc in (event.get("exception", {})).get("values", []):
-        if "value" in exc:
-            messages.append(exc.get("value"))
+    if "logentry" in event and "message" in event.get("logentry", {}) and event.get("logentry", {}).get("message") is not None:
+        messages.append(event.get("logentry", {}).get("message"))
+    if "exception" in event and event.get("exception") is not None:
+        for exc in event.get("exception", {}).get("values", []):
+            if "value" in exc:
+                messages.append(exc.get("value"))
 
     matched = False
     for message in messages:

--- a/codecov-cli/codecov_cli/opentelemetry.py
+++ b/codecov-cli/codecov_cli/opentelemetry.py
@@ -22,11 +22,15 @@ def _before_send(event, hint):
         if "value" in exc:
             messages.append(exc.get("value"))
 
+    matched = False
     for message in messages:
         for pattern in _SAMPLED_MESSAGES:
-            if pattern in message and random.randint(1, _SAMPLE_RATE) != 1:
-                return None
+            if pattern in message:
+                matched = True
+                break
 
+    if matched and random.randint(1, _SAMPLE_RATE) != 1:
+        return None
     return event
 
 

--- a/codecov-cli/codecov_cli/opentelemetry.py
+++ b/codecov-cli/codecov_cli/opentelemetry.py
@@ -1,10 +1,27 @@
 import os
+import random
 
 import sentry_sdk
 
 from codecov_cli import __version__
 
 _SKIP_TAG_KEYS = {"branch", "flags", "commit_sha", "env_vars"}
+_SAMPLED_MESSAGES = [
+    "Token required",
+]
+_SAMPLE_RATE = 100
+
+
+def _before_send(event, hint):
+    message = (event.get("logentry") or {}).get("message", "")
+    if not message:
+        message = event.get("message", "")
+    for pattern in _SAMPLED_MESSAGES:
+        if pattern in message:
+            if random.randint(1, _SAMPLE_RATE) != 1:
+                return None
+            break
+    return event
 
 
 def init_telem(ctx):
@@ -20,6 +37,7 @@ def init_telem(ctx):
         enable_tracing=True,
         environment=os.getenv("CODECOV_ENV", "production"),
         release=f"cli@{__version__}",
+        before_send=_before_send,
     )
 
 

--- a/codecov-cli/codecov_cli/opentelemetry.py
+++ b/codecov-cli/codecov_cli/opentelemetry.py
@@ -12,15 +12,26 @@ _SAMPLED_MESSAGES = [
 _SAMPLE_RATE = 100
 
 
+def _collect_messages(event):
+    msg = (event.get("logentry") or {}).get("message", "")
+    if msg:
+        yield msg
+    msg = event.get("message", "")
+    if msg:
+        yield msg
+    for exc in (event.get("exception") or {}).get("values", []):
+        val = exc.get("value", "")
+        if val:
+            yield val
+
+
 def _before_send(event, hint):
-    message = (event.get("logentry") or {}).get("message", "")
-    if not message:
-        message = event.get("message", "")
-    for pattern in _SAMPLED_MESSAGES:
-        if pattern in message:
-            if random.randint(1, _SAMPLE_RATE) != 1:
-                return None
-            break
+    for message in _collect_messages(event):
+        for pattern in _SAMPLED_MESSAGES:
+            if pattern in message:
+                if random.randint(1, _SAMPLE_RATE) != 1:
+                    return None
+                return event
     return event
 
 


### PR DESCRIPTION
## Summary

- Adds a `before_send` hook to Sentry SDK init that samples "Token required" error events at 1% (1 in 100), dropping the rest
- Issue [CLI-S](https://codecov.sentry.io/issues/CLI-S) has ~21M occurrences flooding Sentry; this reduces volume while still capturing representative samples
- The sampling pattern list (`_SAMPLED_MESSAGES`) is extensible for future high-volume errors

## Test plan

- [ ] Verify existing tests pass (`pytest tests/helpers/test_args.py`)
- [ ] Confirm other Sentry events (non-"Token required") are unaffected and always sent
- [ ] After deploy, monitor CLI-S event volume in Sentry to confirm ~99% reduction